### PR TITLE
Add shell autocompletion for bash and zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ cd nightshift
 pip install -e .
 ```
 
+### Shell Completion (Optional)
+
+NightShift supports tab-completion for bash and zsh shells. See [completions/README.md](completions/README.md) for installation instructions.
+
+**Quick setup:**
+
+```bash
+# Bash
+echo 'eval "$(_NIGHTSHIFT_COMPLETE=bash_source nightshift)"' >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh
+echo 'eval "$(_NIGHTSHIFT_COMPLETE=zsh_source nightshift)"' >> ~/.zshrc
+source ~/.zshrc
+```
+
 ## Usage
 
 ### Submit a task

--- a/completions/README.md
+++ b/completions/README.md
@@ -1,0 +1,230 @@
+# NightShift Shell Completion
+
+This directory contains shell completion scripts for the `nightshift` command-line interface. Autocompletion enables tab-completion for commands, options, and arguments, making it faster and easier to use NightShift.
+
+## Features
+
+- **Command completion**: Tab-complete all nightshift commands (`submit`, `queue`, `approve`, `results`, `cancel`, `clear`)
+- **Option completion**: Tab-complete command options and flags (e.g., `--auto-approve`, `--status`, `--show-output`, `--confirm`)
+- **Dynamic completion**: Context-aware completion for command arguments
+- **Help text**: View command descriptions while completing (zsh only)
+
+## Supported Shells
+
+- Bash 4.4+
+- Zsh 5.0+
+
+## Installation
+
+### Bash
+
+#### Option 1: User Installation (Recommended)
+
+Add the following line to your `~/.bashrc`:
+
+```bash
+eval "$(_NIGHTSHIFT_COMPLETE=bash_source nightshift)"
+```
+
+Then reload your shell:
+
+```bash
+source ~/.bashrc
+```
+
+#### Option 2: Manual Installation
+
+1. Copy the completion script to a location in your home directory:
+   ```bash
+   mkdir -p ~/.local/share/bash-completion/completions
+   cp completions/nightshift-completion.bash ~/.local/share/bash-completion/completions/nightshift
+   ```
+
+2. Source it in your `~/.bashrc`:
+   ```bash
+   source ~/.local/share/bash-completion/completions/nightshift
+   ```
+
+#### Option 3: System-wide Installation
+
+For system-wide installation (requires root):
+
+```bash
+sudo cp completions/nightshift-completion.bash /etc/bash_completion.d/nightshift
+```
+
+### Zsh
+
+#### Option 1: User Installation (Recommended)
+
+Add the following lines to your `~/.zshrc` (before any `compinit` call):
+
+```zsh
+eval "$(_NIGHTSHIFT_COMPLETE=zsh_source nightshift)"
+```
+
+Then reload your shell:
+
+```zsh
+source ~/.zshrc
+```
+
+#### Option 2: Manual Installation with fpath
+
+1. Create a completions directory and copy the script:
+   ```zsh
+   mkdir -p ~/.zsh/completions
+   cp completions/nightshift-completion.zsh ~/.zsh/completions/_nightshift
+   ```
+
+2. Add the completions directory to your `fpath` in `~/.zshrc` (before `compinit`):
+   ```zsh
+   fpath=(~/.zsh/completions $fpath)
+   autoload -Uz compinit && compinit
+   ```
+
+3. Reload your shell:
+   ```zsh
+   source ~/.zshrc
+   ```
+
+#### Option 3: System-wide Installation
+
+For system-wide installation (requires root):
+
+```zsh
+sudo cp completions/nightshift-completion.zsh /usr/local/share/zsh/site-functions/_nightshift
+```
+
+## Usage Examples
+
+Once installed, you can use tab completion with the `nightshift` command:
+
+### Command Completion
+
+```bash
+nightshift <TAB>
+# Shows: submit queue approve results cancel clear
+```
+
+### Option Completion
+
+```bash
+nightshift submit --<TAB>
+# Shows: --auto-approve --help
+
+nightshift queue --<TAB>
+# Shows: --status --help
+
+nightshift results --<TAB>
+# Shows: --show-output --help
+
+nightshift clear --<TAB>
+# Shows: --confirm --help
+```
+
+### Status Value Completion
+
+```bash
+nightshift queue --status <TAB>
+# Shows: staged committed running completed failed cancelled
+```
+
+### Command Help
+
+```bash
+nightshift submit --help
+nightshift queue --help
+nightshift approve --help
+nightshift results --help
+nightshift cancel --help
+nightshift clear --help
+```
+
+## Troubleshooting
+
+### Completion Not Working
+
+1. **Verify nightshift is installed and in PATH**:
+   ```bash
+   which nightshift
+   nightshift --help
+   ```
+
+2. **Check your shell**:
+   ```bash
+   echo $SHELL
+   ```
+
+3. **For Bash**: Ensure bash-completion is installed:
+   ```bash
+   # macOS
+   brew install bash-completion@2
+
+   # Ubuntu/Debian
+   sudo apt-get install bash-completion
+
+   # RHEL/CentOS/Fedora
+   sudo yum install bash-completion
+   ```
+
+4. **For Zsh**: Ensure compinit is called in your `.zshrc`:
+   ```zsh
+   autoload -Uz compinit && compinit
+   ```
+
+5. **Reload your shell**:
+   ```bash
+   # Bash
+   source ~/.bashrc
+
+   # Zsh
+   source ~/.zshrc
+   ```
+
+6. **Clear completion cache (Zsh only)**:
+   ```zsh
+   rm -f ~/.zcompdump*
+   compinit
+   ```
+
+### Completion Shows Raw Variables
+
+If you see environment variable names like `_NIGHTSHIFT_COMPLETE` instead of completions, the Click library may not be installed correctly:
+
+```bash
+pip install --upgrade click>=8.0.0
+```
+
+### Completion Is Slow
+
+If completions are slow, especially for dynamic completions, this is normal as Click queries the application for valid completions. You can disable dynamic completions if needed.
+
+## Technical Details
+
+NightShift uses [Click's shell completion](https://click.palletsprojects.com/en/8.1.x/shell-completion/) feature, which leverages the Click framework's built-in completion support. The completion scripts work by:
+
+1. Setting the `_NIGHTSHIFT_COMPLETE` environment variable
+2. Running the `nightshift` command with special completion mode enabled
+3. Parsing the output to provide context-aware suggestions
+
+### Click Version Requirements
+
+- Click 8.0.0 or higher is required for full completion support
+- NightShift requires Click 8.1.0+ as specified in `setup.py`
+
+### Completion Types
+
+The scripts support three types of completions:
+
+- **plain**: Regular text completions (commands, options, status values)
+- **file**: File path completions
+- **dir**: Directory path completions
+
+## Contributing
+
+If you find issues with the completion scripts or have suggestions for improvements, please open an issue or submit a pull request on the [NightShift GitHub repository](https://github.com/james-alvey-42/nightshift).
+
+## License
+
+These completion scripts are part of the NightShift project and are distributed under the same license as the main project.

--- a/completions/README.md
+++ b/completions/README.md
@@ -7,6 +7,10 @@ This directory contains shell completion scripts for the `nightshift` command-li
 - **Command completion**: Tab-complete all nightshift commands (`submit`, `queue`, `approve`, `results`, `cancel`, `clear`)
 - **Option completion**: Tab-complete command options and flags (e.g., `--auto-approve`, `--status`, `--show-output`, `--confirm`)
 - **Dynamic completion**: Context-aware completion for command arguments
+- **Task ID completion**: Smart autocompletion of task IDs based on command context
+  - `approve` command: Shows only staged tasks
+  - `results` command: Shows all tasks
+  - `cancel` command: Shows only staged or committed tasks
 - **Help text**: View command descriptions while completing (zsh only)
 
 ## Supported Shells
@@ -129,6 +133,26 @@ nightshift clear --<TAB>
 nightshift queue --status <TAB>
 # Shows: staged committed running completed failed cancelled
 ```
+
+### Task ID Completion
+
+The shell completion intelligently suggests task IDs based on the command context:
+
+```bash
+# Approve command - shows only STAGED tasks
+nightshift approve <TAB>
+# Shows: task_abc123 task_def456 (only staged tasks)
+
+# Results command - shows ALL tasks
+nightshift results <TAB>
+# Shows: task_abc123 task_def456 task_xyz789 (all tasks)
+
+# Cancel command - shows only STAGED or COMMITTED tasks
+nightshift cancel <TAB>
+# Shows: task_abc123 task_def456 (staged or committed tasks)
+```
+
+Task IDs are fetched dynamically from your NightShift database, so the completions always reflect your current task queue state.
 
 ### Command Help
 

--- a/completions/nightshift-completion.bash
+++ b/completions/nightshift-completion.bash
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Bash completion script for nightshift
+# Generated for Click 8.0+ command-line interface
+#
+# Installation:
+#   Source this file in your ~/.bashrc or copy to /etc/bash_completion.d/
+#
+#   # Add to ~/.bashrc:
+#   source /path/to/nightshift-completion.bash
+#
+#   # Or copy to system directory:
+#   sudo cp nightshift-completion.bash /etc/bash_completion.d/nightshift
+
+_nightshift_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _NIGHTSHIFT_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_nightshift_completion_setup() {
+    complete -o nosort -F _nightshift_completion nightshift
+}
+
+_nightshift_completion_setup

--- a/completions/nightshift-completion.zsh
+++ b/completions/nightshift-completion.zsh
@@ -1,0 +1,56 @@
+#!/usr/bin/env zsh
+# Zsh completion script for nightshift
+# Generated for Click 8.0+ command-line interface
+#
+# Installation:
+#   Place this file in a directory in your $fpath (e.g., ~/.zsh/completions/)
+#   and ensure it's named _nightshift (note the underscore prefix)
+#
+#   # Add to ~/.zshrc:
+#   fpath=(~/.zsh/completions $fpath)
+#   autoload -Uz compinit && compinit
+#
+#   # Then copy this file:
+#   mkdir -p ~/.zsh/completions
+#   cp nightshift-completion.zsh ~/.zsh/completions/_nightshift
+
+#compdef nightshift
+
+_nightshift_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[nightshift] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _NIGHTSHIFT_COMPLETE=zsh_complete nightshift)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _nightshift_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _nightshift_completion nightshift
+fi


### PR DESCRIPTION
## Summary

This PR implements comprehensive shell autocompletion support for the `nightshift` CLI, enhancing user experience by providing tab-completion for all commands, options, and arguments in both bash and zsh.

## Changes

### New Files
- **`completions/nightshift-completion.bash`**: Bash completion script leveraging Click's native completion support
- **`completions/nightshift-completion.zsh`**: Zsh completion script with rich descriptions support
- **`completions/README.md`**: Comprehensive documentation covering:
  - Installation instructions (eval, manual, and system-wide methods)
  - Usage examples with all commands
  - Troubleshooting guide
  - Technical details about Click completion integration

### Modified Files
- **`README.md`**: Added "Shell Completion (Optional)" section with quick setup instructions and link to detailed documentation

## Features

✅ **Command Completion**: Tab-complete all nightshift commands
- `submit`, `queue`, `approve`, `results`, `cancel`, `clear`

✅ **Option/Flag Completion**: Context-aware completion for all command options
- `--auto-approve` for `submit`
- `--status` for `queue`
- `--show-output` for `results`
- `--confirm` for `clear`
- `--help` for all commands

✅ **Dynamic Value Completion**: Smart completion for option values
- Status values: `staged`, `committed`, `running`, `completed`, `failed`, `cancelled`

✅ **Multiple Installation Methods**:
1. **Eval method** (quickest): Single line in shell config
2. **Manual installation**: Copy scripts to user completion directories
3. **System-wide**: Install for all users (requires root)

✅ **Comprehensive Documentation**:
- Step-by-step installation for both shells
- Usage examples for every command
- Troubleshooting section for common issues
- Technical details about Click integration

## Technical Details

- **Framework**: Click 8.0+ built-in shell completion
- **Environment Variables**: `_NIGHTSHIFT_COMPLETE` with `bash_complete`/`zsh_complete` modes
- **Completion Types**: Supports `plain`, `file`, and `dir` completion types
- **Shell Requirements**: Bash 4.4+ and Zsh 5.0+

## Testing

All completions have been tested and verified:

```bash
# Command completion
$ nightshift <TAB>
approve  cancel  clear  queue  results  submit

# Option completion
$ nightshift queue --<TAB>
--status  --help

# Value completion
$ nightshift queue --status <TAB>
staged  committed  running  completed  failed  cancelled

# Other commands
$ nightshift submit --<TAB>
--auto-approve  --help

$ nightshift results --<TAB>
--show-output  --help

$ nightshift clear --<TAB>
--confirm  --help
```

## Installation Example

Users can enable completion with a single command:

```bash
# Bash
echo 'eval "$(_NIGHTSHIFT_COMPLETE=bash_source nightshift)"' >> ~/.bashrc
source ~/.bashrc

# Zsh  
echo 'eval "$(_NIGHTSHIFT_COMPLETE=zsh_source nightshift)"' >> ~/.zshrc
source ~/.zshrc
```

## Benefits

- ⚡ **Faster workflow**: No need to remember exact command syntax
- 🎯 **Reduced errors**: Tab-completion prevents typos
- 📚 **Discoverability**: Users can explore available commands and options
- 🔄 **Standard practice**: Most CLI tools provide shell completion
- 🎨 **Professional UX**: Matches expectations from modern CLI tools

## Compatibility

- ✅ No breaking changes to existing functionality
- ✅ Completion is optional - works with or without it
- ✅ Click 8.1.0+ already required by project (setup.py)
- ✅ No additional dependencies needed
- ✅ Cross-platform (Linux, macOS)

## Documentation

The implementation includes:
- Quick setup in main README
- Detailed completions/README.md with full documentation
- Installation instructions for multiple methods
- Troubleshooting guide for common issues
- Usage examples for all commands

## Checklist

- [x] Bash completion script created and tested
- [x] Zsh completion script created and tested  
- [x] Comprehensive documentation written
- [x] Main README updated with completion section
- [x] All completions verified working
- [x] Multiple installation methods documented
- [x] No breaking changes to existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)