### PR TITLE
Fix task planner parsing for structured_output format

### DIFF
--- a/nightshift/core/task_planner.py
+++ b/nightshift/core/task_planner.py
@@ -131,7 +131,10 @@ Guidelines:
             wrapper = json.loads(result.stdout)
 
             # Extract the actual result from the wrapper
-            if "result" in wrapper:
+            # Check for structured_output first (new --json-schema format)
+            if "structured_output" in wrapper:
+                plan = wrapper["structured_output"]
+            elif "result" in wrapper and wrapper["result"]:
                 result_text = wrapper["result"]
 
                 # Remove markdown code fences if present


### PR DESCRIPTION
## Summary
Fixes the task planner's JSON parsing to handle the new `structured_output` format returned by Claude CLI when using `--json-schema`.

Closes #1

## Problem
The task planner was failing with:
```
[ERROR] Failed to parse planning response as JSON: Expecting value: line 1 column 1 (char 0)
```

When using `--json-schema`, Claude CLI now returns:
```json
{
  "result": "",
  "structured_output": {...}
}
```

The code checked if `"result"` existed but didn't verify it was non-empty before calling `json.loads("")`, causing the error.

## Solution
- Check for `"structured_output"` field first (new --json-schema format)
- Add truthiness check for `"result"` field before parsing: `if "result" in wrapper and wrapper["result"]`
- Maintains backward compatibility with older response formats

## Changes
File: `nightshift/core/task_planner.py` (lines 134-137)
- Added check for `structured_output` field
- Added non-empty check for `result` field

## Testing
After clearing Python cache, test with:
```bash
nightshift submit "test task description"
```

Previously failed with JSON parsing error, now successfully parses the structured output.