### PR TITLE
🐛 Fix Gemini MCP sandbox authentication and device file access

### DIFF
--- a/nightshift/core/agent_manager.py
+++ b/nightshift/core/agent_manager.py
@@ -159,6 +159,14 @@ class AgentManager:
                 except Exception as e:
                     self.logger.warning(f"Could not load GH_TOKEN: {e}")
 
+            # Pass through MCP server API keys to sandboxed environment
+            # Note: We don't pass ANTHROPIC_API_KEY as it interferes with Claude authentication
+            mcp_api_keys = ["GEMINI_API_KEY", "OPENAI_API_KEY"]
+            for key in mcp_api_keys:
+                if key in os.environ:
+                    env[key] = os.environ[key]
+                    self.logger.info(f"Passing {key} to sandboxed environment")
+
             # Create output file path immediately
             output_file = self.output_dir / f"{task.task_id}_output.json"
 


### PR DESCRIPTION
## Summary

This PR fixes two critical issues preventing the Gemini MCP server (and potentially other MCP servers) from working correctly in NightShift's sandboxed execution environment.

## Issues Fixed

### 1. MCP API Key Authentication
**Problem**: MCP servers requiring API keys (Gemini, OpenAI) couldn't authenticate because their API keys weren't being passed through to the sandboxed subprocess.

**Solution**: Added explicit pass-through of `GEMINI_API_KEY` and `OPENAI_API_KEY` environment variables to the sandboxed Claude process (similar to existing `CLAUDE_CODE_OAUTH_TOKEN` and `GH_TOKEN` handling).

**Note**: `ANTHROPIC_API_KEY` is explicitly excluded to avoid interfering with Claude's OAuth authentication.

### 2. Device File Access for MCP Servers
**Problem**: MCP servers were getting "Operation not permitted" errors when trying to write to `/dev/null` for subprocess management and logging. This was only allowed when `needs_git=True`, but MCP servers need it regardless.

**Solution**: Changed device file access (`/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/dtracehelper`) from conditional to always allowed in sandbox profiles. These are standard Unix patterns that are safe to permit universally.

## Changes

- **nightshift/core/agent_manager.py**: Pass MCP API keys to sandboxed environment (lines 162-168)
- **nightshift/core/sandbox.py**: Always allow device file writes (lines 135-141)

## Testing

Tested with Gemini MCP server in sandboxed tasks - confirmed both API authentication and agent state file writes now work correctly.

## Related Issues

Resolves issues with Gemini MCP reporting:
- `[Errno 1] Operation not permitted: '.mcp_handley_lab/agents/_session_*.json'`
- `/dev/null` access blocked errors

🌙 Generated by NightShift