### PR TITLE
🐛 Fix: Add automatic migration for allowed_directories column

### DIFF
--- a/nightshift/core/task_queue.py
+++ b/nightshift/core/task_queue.py
@@ -129,6 +129,10 @@ class TaskQueue:
             cursor.execute("PRAGMA table_info(tasks)")
             columns = [row[1] for row in cursor.fetchall()]
 
+            if 'allowed_directories' not in columns:
+                conn.execute("ALTER TABLE tasks ADD COLUMN allowed_directories TEXT")
+                conn.commit()
+
             if 'needs_git' not in columns:
                 conn.execute("ALTER TABLE tasks ADD COLUMN needs_git INTEGER")
                 conn.commit()


### PR DESCRIPTION
Adds automatic migration logic for the `allowed_directories` column in TaskQueue._init_db(), preventing "table tasks has no column named allowed_directories" errors on existing databases.

Previously, users with databases created before the allowed_directories feature would encounter this error when running nightshift commands. This change ensures the column is automatically added on initialization, consistent with other columns like needs_git, process_id, and timeout_seconds.

Fixes the issue where manual migration was required via nightshift/migrations/add_allowed_directories.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)